### PR TITLE
feat: skip pr-dependency-checklist validate job on merge_group

### DIFF
--- a/.github/workflows/pr-dependency-checklist.yml
+++ b/.github/workflows/pr-dependency-checklist.yml
@@ -33,7 +33,10 @@ concurrency:
 jobs:
   validate:
     name: Update and validate PR checklist
-    if: github.event.pull_request.draft == false
+    # Skip on merge_group: this job needs PR data (PR number, base/head SHA, PR body) that does not
+    # exist in a merge queue run. The job is still evaluated (the caller invokes this reusable
+    # workflow), so it reports "skipped" = success and satisfies the required check without hanging.
+    if: ${{ github.event_name != 'merge_group' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The job needs PR data (PR number, base/head SHA, PR body) that doesn't exist in a merge queue run. Guarding with `github.event_name != 'merge_group'` makes it skip (reporting success) when invoked from a caller's merge_group event, so a required pr_dependency_checklist check no longer hangs the merge queue.