### PR TITLE
fix: fall back to master workflows ref for merge-queue refs

### DIFF
--- a/.github/workflows/validate-pnpm-config.yml
+++ b/.github/workflows/validate-pnpm-config.yml
@@ -63,9 +63,10 @@ jobs:
           set -euo pipefail
           ref="${WORKFLOW_REF##*@}"
 
-          # Caller workflows on pull_request can resolve to refs/pull/<id>/merge, which
-          # does not exist in the workflows repository. Fall back to the configured branch.
-          if [[ -z "${ref}" || "${ref}" == refs/pull/* ]]; then
+          # Caller workflows on pull_request resolve to refs/pull/<id>/merge and on
+          # merge_group to refs/heads/gh-readonly-queue/*, neither of which exists in
+          # the workflows repository. Fall back to the configured branch.
+          if [[ -z "${ref}" || "${ref}" == refs/pull/* || "${ref}" == refs/heads/gh-readonly-queue/* ]]; then
             ref="${WORKFLOWS_FALLBACK_REF}"
           elif [[ "${ref}" == refs/heads/* ]]; then
             ref="${ref#refs/heads/}"


### PR DESCRIPTION
github.workflow_ref on merge_group events resolves to the caller's refs/heads/gh-readonly-queue/* ref, which does not exist in the workflows repository. The validator-script checkout then fails with git exit code 1 and dequeues the PR from the merge queue.

Treat merge-queue refs like refs/pull/* and fall back to master.