### PR TITLE
fix: fall back to master workflows ref for merge-queue refs

### DIFF
--- a/.github/workflows/validate-pnpm-config.yml
+++ b/.github/workflows/validate-pnpm-config.yml
@@ -63,9 +63,10 @@ jobs:
           set -euo pipefail
           ref="${WORKFLOW_REF##*@}"
 
-          # Caller workflows on pull_request can resolve to refs/pull/<id>/merge, which
-          # does not exist in the workflows repository. Fall back to the configured branch.
-          if [[ -z "${ref}" || "${ref}" == refs/pull/* ]]; then
+          # Caller workflows on pull_request resolve to refs/pull/<id>/merge and on
+          # merge_group to refs/heads/gh-readonly-queue/*, neither of which exists in
+          # the workflows repository. Fall back to the configured branch.
+          if [[ -z "${ref}" || "${ref}" == refs/pull/* || "${ref}" == refs/heads/gh-readonly-queue/* ]]; then
             ref="${WORKFLOWS_FALLBACK_REF}"
           elif [[ "${ref}" == refs/heads/* ]]; then
             ref="${ref#refs/heads/}"


### PR DESCRIPTION
## Problem

`fyle-app` merge-queue runs of the `Validate pnpm config` reusable workflow fail at the **Checkout workflows repository for validator script** step:

```
/usr/bin/git fetch ... +refs/heads/gh-readonly-queue/master/pr-15300-a1b57abc...*
The process '/usr/bin/git' failed with exit code 1
```

The "Resolve workflows repository ref" step derives the checkout ref from `github.workflow_ref`, which is the **caller's** ref. On `merge_group` events that is `refs/heads/gh-readonly-queue/master/pr-<n>-<sha>` — a branch that only exists in the caller repo (`fyle-app`), not in `fylein/workflows`. The checkout fetch fails, the job fails, and the PR is dequeued from the merge queue.

The existing fallback (#16) only covered `refs/pull/*` (pull_request events).

## Fix

Treat merge-queue refs (`refs/heads/gh-readonly-queue/*`) like `refs/pull/*`: fall back to `master` when checking out this repo for the validator script.

Note: this only changes **which ref of this repo the validator script is fetched from**. The validation itself still runs fully, against the merge-queue commit of the caller repo — nothing is skipped.